### PR TITLE
Raise RateNotFoundError when an incorrect code is given

### DIFF
--- a/lib/open_exchange_rates/rates.rb
+++ b/lib/open_exchange_rates/rates.rb
@@ -10,6 +10,13 @@ module OpenExchangeRates
       end
     end
 
+    class RateNotFoundError < StandardError
+      def initialize(from_curr, to_curr)
+        msg = "Rate not found for #{from_curr} => #{to_curr}"
+        super(msg)
+      end
+    end
+
     attr_reader :app_id
 
     def initialize(options = {})
@@ -31,6 +38,10 @@ module OpenExchangeRates
 
       from_curr = response.base_currency if from_curr.empty?
       to_curr = response.base_currency if to_curr.empty?
+
+      unless rates[from_curr] && rates[to_curr]
+        raise RateNotFoundError.new(from_curr, to_curr)
+      end
 
       if from_curr == to_curr
         rate = 1

--- a/test/rates_test.rb
+++ b/test/rates_test.rb
@@ -206,7 +206,21 @@ class TestOpenExchangeRates < Test::Unit::TestCase
       fx.exchange_rate(:from => "USD", :to => "EUR")
       fx.exchange_rate(:from => "USD", :to => "EUR", :on => "2012-04-10")
       fx.exchange_rate(:from => "USD", :to => "AUD", :on => "2012-05-10")
+
     end
+  end
+
+  def test_error_conditions
+    fx = OpenExchangeRates::Rates.new
+
+    assert_raise(OpenExchangeRates::Rates::RateNotFoundError) do
+      fx.exchange_rate(:from => "???", :to => "AUD", :on => "2012-05-10")
+    end
+
+    assert_raise(OpenExchangeRates::Rates::RateNotFoundError) do
+      fx.exchange_rate(:from => "USD", :to => "???", :on => "2012-05-10")
+    end
+
   end
 
 private


### PR DESCRIPTION
Hi there,

First of all thanks for making this Gem. It saved me a lot of time today. 

I ran across this problem when I accidentally mistyped a currency code in my app. Unfortunately it would cause the Gem to blow up with errors like `TypeError: nil can't be coerced into Fixnum` etc.

This returns a `RateNotFoundError` when rate isn't found between the two given currencies, which allows the Gem user to add a `begin..rescue RateNotFoundError.. end` block to their code.

Cheers!