### PR TITLE
fix fx rounding error for tiny amounts

### DIFF
--- a/lib/open_exchange_rates/rates.rb
+++ b/lib/open_exchange_rates/rates.rb
@@ -44,13 +44,13 @@ module OpenExchangeRates
       end
 
       if from_curr == to_curr
-        rate = 1
+        rate = 1.0
       elsif from_curr == response.base_currency
         rate = rates[to_curr]
       elsif to_curr == response.base_currency
-        rate = 1 / rates[from_curr]
+        rate = 1.0 / rates[from_curr]
       else
-        rate = rates[to_curr] * (1 / rates[from_curr])
+        rate = rates[to_curr] * (1.0 / rates[from_curr])
       end
       round(rate, 6)
     end

--- a/test/rates_test.rb
+++ b/test/rates_test.rb
@@ -57,6 +57,9 @@ class TestOpenExchangeRates < Test::Unit::TestCase
 
     assert_equal 5.944602, fx.exchange_rate(:from => "AUD", :to => "HRK")
     assert_equal 0.168220, fx.exchange_rate(:from => "HRK", :to => "AUD")
+
+    assert_equal 0.00023, fx.exchange_rate(:from => 'SLL', to: 'USD')
+    assert_equal 4350, fx.exchange_rate(:from => 'USD', to: 'SLL')
   end
 
   def test_exchange_rate_on_specific_date


### PR DESCRIPTION
This was a pretty big oops for us, specifically when a client was trying to convert between SLL and USD. The effective exchange rate was coming back as '0.0' because the numerator was an integer rather than a float.