### PR TITLE
Base URL updated

### DIFF
--- a/lib/open_exchange_rates.rb
+++ b/lib/open_exchange_rates.rb
@@ -6,7 +6,7 @@ require "open_exchange_rates/response"
 require "open_exchange_rates/rates"
 
 module OpenExchangeRates
-  BASE_URL = "http://openexchangerates.org"
+  BASE_URL = "http://openexchangerates.org/api"
   LATEST_URL = "#{BASE_URL}/latest.json"
 
   class << self

--- a/lib/open_exchange_rates.rb
+++ b/lib/open_exchange_rates.rb
@@ -6,7 +6,7 @@ require "open_exchange_rates/response"
 require "open_exchange_rates/rates"
 
 module OpenExchangeRates
-  BASE_URL = "http://openexchangerates.org/api"
+  BASE_URL = "http://openexchangerates.org/api".freeze
   LATEST_URL = "#{BASE_URL}/latest.json"
 
   class << self


### PR DESCRIPTION
API url was changed from http://openexchangerates.org to
http://openexchangerates.org/api