### PR TITLE
Support for ruby version 3.0.0

### DIFF
--- a/lib/open_exchange_rates/rates.rb
+++ b/lib/open_exchange_rates/rates.rb
@@ -91,12 +91,12 @@ module OpenExchangeRates
 
     def parse_latest
       @latest_parser ||= OpenExchangeRates::Parser.new
-      @latest_parser.parse(open("#{OpenExchangeRates::LATEST_URL}?app_id=#{@app_id}"))
+      @latest_parser.parse(URI.open("#{OpenExchangeRates::LATEST_URL}?app_id=#{@app_id}"))
     end
 
     def parse_on(date_string)
       @on_parser = OpenExchangeRates::Parser.new
-      @on_parser.parse(open("#{OpenExchangeRates::BASE_URL}/historical/#{date_string}.json?app_id=#{@app_id}"))
+      @on_parser.parse(URI.open("#{OpenExchangeRates::BASE_URL}/historical/#{date_string}.json?app_id=#{@app_id}"))
     end
 
   end


### PR DESCRIPTION
open-uri used to (before Ruby 3.0.0) overwrite Kernel#open with its own version which also supports reading from external URLs rather than simply opening local files or running commands.

Mixing those two use-cases was quite dangerous and had the potential for serious vulnerabilities if the passed URL was not ensured to be safe everywhere (including third-party code using Kernel#open).

As such, this behavior to overwrite Kernel#open was deprecated in Ruby 2.7 and finally removed in Ruby 3.0. To open an external URL, you have to use URI.open directly 